### PR TITLE
fix: handle lowercase z in ISO datetime parser

### DIFF
--- a/backend/app/utils/helpers.py
+++ b/backend/app/utils/helpers.py
@@ -7,13 +7,18 @@ from typing import Optional
 
 
 def parse_iso_datetime(value: str | None) -> Optional[dt.datetime]:
-    """Parse an ISO8601 datetime string into a datetime object.
+    """Parse an ISO8601 datetime string into a :class:`datetime` object.
 
-    Returns ``None`` if the value is falsy or cannot be parsed.
+    The standard ``datetime.fromisoformat`` helper does not accept a lowercase
+    ``z`` as the UTC designator. Some data sources provide timestamps that end
+    with ``z`` instead of the canonical ``Z``. This function normalises that
+    case and returns ``None`` if the value cannot be parsed.
     """
     if not value:
         return None
     try:
+        if value.endswith("z"):
+            value = value[:-1] + "Z"
         return dt.datetime.fromisoformat(value)
-    except Exception:
+    except ValueError:
         return None

--- a/backend/tests/test_helpers.py
+++ b/backend/tests/test_helpers.py
@@ -1,0 +1,13 @@
+import datetime as dt
+
+from app.utils.helpers import parse_iso_datetime
+
+
+def test_parse_iso_datetime_lowercase_z():
+    value = "2023-05-06T12:00:00z"
+    result = parse_iso_datetime(value)
+    assert result == dt.datetime(2023, 5, 6, 12, 0, 0, tzinfo=dt.timezone.utc)
+
+
+def test_parse_iso_datetime_invalid_returns_none():
+    assert parse_iso_datetime("not-a-date") is None


### PR DESCRIPTION
## Summary
- ensure `parse_iso_datetime` accepts lowercase `z` as UTC indicator
- add regression tests for lowercase `z` and invalid strings

## Testing
- `PYTHONPATH=backend pytest backend/tests/test_helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_68a92845e6b48330a0faeebcbfbadf2a